### PR TITLE
Fix index out of range error when there are no previous versions of an object

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,23 +9,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip
-          restore-keys: ${{ runner.os }}-pip
+          python-version: 3.9
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          installer-parallel: true
+
           # virtualenvs-path: ~/.venv
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
-        run: timeout 10s poetry run pip --version || rm -rf .venv
-
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v2
@@ -34,22 +27,22 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       # install dependencies if cache does not exist
       - name: Check cache and install dependencies
-        run: poetry install
+        run: poetry install --no-interaction --no-root
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      # poetry run pre-commit run --all-files
       - name: Run linters
         run: |
-          source .venv/bin/activate
-          # flake8 .
-          black . --check
-          isort .
+            poetry run pre-commit run --all-files
+
 
   test:
-    needs: linting
+# XXX    needs: linting
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9" ]
+        python-version: [ "3.7", "3.8", "3.9" ]
+        #django-version: [ "django>=2.2,<3", "django>=3.1,<4" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
@@ -58,36 +51,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-      # install dependencies if cache does not exist
-      - name: Check cache and install dependencies
-        run: poetry install
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      - name: Run tests
+      - name: Install dependencies
         run: |
-          source .venv/bin/activate
-          pip install tox-gh-actions
-          tox
-          coverage report
-      # upload coverage stats
-      - name: Upload coverage
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: true
-
-
-      # upload coverage stats
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Run tests
+        run: tox
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
     hooks:
       - id: system
         name: flake8
-        entry: poetry run flake8 .
+        entry: poetry run flake8 src
         language: system
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 
 ## Unreleased
+### Fixed
+- fix list index of range issue in version admin
 
 
 ## 1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 
 ## Unreleased
+
+
+## 1.0.2
 ### Fixed
 - fix list index of range issue in version admin
 

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,7 @@
 Unreleased:
   added: []
-  fixed: []
+  fixed:
+  - fix list index of range issue in version admin
   changed: []
   deprecated: []
   removed: []

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,7 +1,6 @@
 Unreleased:
   added: []
-  fixed:
-  - fix list index of range issue in version admin
+  fixed: []
   changed: []
   deprecated: []
   removed: []
@@ -37,3 +36,6 @@ Unreleased:
 1.0.1:
   fixed:
   - performance issues in admin version history view
+1.0.2:
+  fixed:
+  - fix list index of range issue in version admin

--- a/src/django_handleref/admin.py
+++ b/src/django_handleref/admin.py
@@ -173,6 +173,9 @@ class VersionAdmin(admin.ModelAdmin):
 
         versions.reverse()
 
+        # If there are no previous versions, return an empty history
+        if not versions:
+            return history
         previous = self.version_cls(versions[0]).previous
 
         for _version in versions:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ python =
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONWARNINGS=once
+extras = dev
 deps =
+    poetry
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,30,31,32}-reversion{2,3,4}
+    py{37,38,39}-django{22,32}-reversion{3,4}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -19,10 +18,7 @@ extras = dev
 deps =
     poetry
     django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
-    reversion2: django-reversion>=2<3
     reversion3: django-reversion>=3<4
     reversion4: django-reversion>=4<5
 whitelist_externals = poetry


### PR DESCRIPTION
Fix index out of range error when there are no previous versions of an object

```
Traceback (most recent call last):
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django/contrib/admin/options.py", line 616, in wrapper
    return self.admin_site.admin_view(view)(*args, **kwargs)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django/contrib/admin/sites.py", line 232, in inner
    return view(request, *args, **kwargs)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django_handleref/admin.py", line 207, in history_view
    history = self.history(listing.result_list)
  File "/srv/www.peeringdb.com/venv/lib/python3.9/site-packages/django_handleref/admin.py", line 176, in history
    previous = self.version_cls(versions[0]).previous

Exception Type: IndexError at /cp/peeringdb_server/facility/11737/history/
Exception Value: list index out of range
```