### PR TITLE
#38 Check type before updating version field

### DIFF
--- a/src/django_handleref/models.py
+++ b/src/django_handleref/models.py
@@ -8,9 +8,10 @@ try:
 
     def handle_version(**kwargs):
         for vs in kwargs.get("versions"):
-            instance = vs.object
-            instance.version = instance.version + 1
-            instance.save()
+            if isinstance(vs.object, HandleRefModel):
+                instance = vs.object
+                instance.version = instance.version + 1
+                instance.save()
 
     reversion.signals.post_revision_commit.connect(handle_version)
 except ImportError:


### PR DESCRIPTION
Application may already use `reversion` but not implement `HandleRefModel` in every model under control of reversion. Check the objects type before updating the `version` field.